### PR TITLE
Updating help link with UCD email

### DIFF
--- a/app/views/6-0-0/design-history/index.html
+++ b/app/views/6-0-0/design-history/index.html
@@ -28,7 +28,7 @@
   </h1>
         <p>
           A record of how our service has iterated.<br>
-          <em>12 January 2024</em>
+          <em>23 February 2024</em>
         </p>
       </div>
     </div>
@@ -95,7 +95,10 @@
 
 
       <h2 class="govuk-heading-m">Added help links</h2>
-      <p>Content was added on all screens to provide users a channel for support.</p>
+      <p>Content was added on all screens to provide users a channel for support. For MVP, link will send an email to the UCD team.</p>
+
+      <h2 class="govuk-heading-m">Added feeback link</h2>
+      <p>A Beta phase banner was added, to provide users with a channel for their feedback about the service. For MVP, link will send an email to the UCD team.</p>
 
       <h2 class="govuk-heading-m">Removed stand alone support page</h2>
       <p>Due to the MVP approach to support channels, the need to a stand alone support screen was reviewed, and instead a link to a shared email address was added.</p>

--- a/app/views/6-0-0/includes/date.html
+++ b/app/views/6-0-0/includes/date.html
@@ -1,1 +1,1 @@
-19 January 2024
+23 February 2024

--- a/app/views/6-0-0/includes/help.html
+++ b/app/views/6-0-0/includes/help.html
@@ -1,2 +1,2 @@
 <h2 class="govuk-heading-m govuk-!-static-padding-top-5">If you need help</h2>
-<p>Email the GOV.UK One Login Fraud Team on <a href="#">email@digital.cabinet-office.gov.uk</a>.</p>
+<p>Email the GOV.UK One Login Fraud Team on <a href="#">di-fraud-pod-ucd-team@digital.cabinet-office.gov.uk</a>.</p>

--- a/app/views/6-0-0/includes/summary.html
+++ b/app/views/6-0-0/includes/summary.html
@@ -6,6 +6,7 @@
   <li>Updated upload flow</li>
   <li>Added new service name</li>
   <li>Added help links</li>
+  <li>Added phase banner feedback link</li>
   <li>Removed stand alone support page</li>
 </ul>
 

--- a/app/views/6-0-0/login.html
+++ b/app/views/6-0-0/login.html
@@ -63,7 +63,7 @@
         text: "Sign in"
       }) }}
       <p class="govuk-body">
-        If you've forgotten your password, <a href="#" class="govuk-link">contact the GOV.UK One Login support team</a>. They'll
+        If you've forgotten your password, <a href="mailto:di-fraud-pod-ucd-team@digital.cabinet-office.gov.uk" class="govuk-link">contact the GOV.UK One Login support team</a>. They'll
         help you reset it.
       </p>
 

--- a/app/views/7-0-0/includes/help.html
+++ b/app/views/7-0-0/includes/help.html
@@ -1,2 +1,2 @@
 <h2 class="govuk-heading-m govuk-!-static-padding-top-5">If you need help</h2>
-<p>Email the GOV.UK One Login Fraud Team on <a href="#">email@digital.cabinet-office.gov.uk</a>.</p>
+<p>Email the GOV.UK One Login Fraud Team on <a href="#">di-fraud-pod-ucd-team@digital.cabinet-office.gov.uk</a>.</p>

--- a/app/views/7-0-0/login.html
+++ b/app/views/7-0-0/login.html
@@ -63,7 +63,7 @@
         text: "Sign in"
       }) }}
       <p class="govuk-body">
-        If you've forgotten your password, <a href="#" class="govuk-link">contact the GOV.UK One Login support team</a>. They'll
+        If you've forgotten your password, <a href="mailto:di-fraud-pod-ucd-team@digital.cabinet-office.gov.uk" class="govuk-link">contact the GOV.UK One Login support team</a>. They'll
         help you reset it.
       </p>
 


### PR DESCRIPTION
For MVP, the help link will go to to the UCD email, so that in private beta, UCD can triage all contact from users.