### PR TITLE
Rename to GOV.UK One Login subject identifier

### DIFF
--- a/app/views/6-0-0/add-ids.html
+++ b/app/views/6-0-0/add-ids.html
@@ -40,7 +40,7 @@ Enter the User IDs– {{ serviceName }} – GOV.UK Prototype Kit
         <div class="govuk-form-group">
           <h1 class="govuk-label-wrapper">
             <label class="govuk-label govuk-label--l" for="user-id">
-              What is the GOV.UK One Login identifier? 
+              What is the GOV.UK One Login subject identifier? 
               <!-- Enter the auth provider ID -->
 
             </label>
@@ -132,7 +132,8 @@ Enter the User IDs– {{ serviceName }} – GOV.UK Prototype Kit
           text: "Continue"
         }) }}
 
-        <details class="govuk-details">
+        
+        <!-- <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
               Help with GOV.UK One Login identifiers
@@ -140,10 +141,9 @@ Enter the User IDs– {{ serviceName }} – GOV.UK Prototype Kit
           </summary>
           <div class="govuk-details__text">
             Supporting content letting the user know how to get hold of a GOV.UK One Login identifier if they need suppport.
-          
-
           </div>
-        </details>
+        </details> -->
+
 
         <details class="govuk-details">
           <summary class="govuk-details__summary">

--- a/app/views/6-0-0/task.html
+++ b/app/views/6-0-0/task.html
@@ -74,7 +74,7 @@ What would you like to do? – {{ serviceName }} – GOV.UK Prototype Kit
             
                 <p>Use this to share information about fraud-related events in your service with GOV.UK One Login and other government services.</p>
       
-                  <p>For each event you add, you'll need to include the user ID and select what type of fraud you suspect it to be about.
+                  <p>For each event you add, you'll need to include the GOV.UK One Login subject identifier and select what type of fraud you suspect it to be about.
                   </p>
                
       
@@ -198,7 +198,7 @@ What would you like to do? – {{ serviceName }} – GOV.UK Prototype Kit
       
           <p>Use this to share information about fraud-related events in your service with GOV.UK One Login and other government services.</p>
 
-            <p>For each event you add, you'll need to include the user ID and select what type of fraud you suspect it to be about.
+            <p>For each event you add, you'll need to include the GOV.UK One Login subject identifier and select what type of fraud you suspect it to be about.
             </p>
          
 

--- a/app/views/7-0-0/add-ids.html
+++ b/app/views/7-0-0/add-ids.html
@@ -132,7 +132,7 @@ Enter the User IDs– {{ serviceName }} – GOV.UK Prototype Kit
           text: "Continue"
         }) }}
 
-        <details class="govuk-details">
+         <!-- <details class="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
               Help with GOV.UK One Login identifiers
@@ -140,10 +140,8 @@ Enter the User IDs– {{ serviceName }} – GOV.UK Prototype Kit
           </summary>
           <div class="govuk-details__text">
             Supporting content letting the user know how to get hold of a GOV.UK One Login identifier if they need suppport.
-          
-
           </div>
-        </details>
+        </details> -->
 
         <details class="govuk-details">
           <summary class="govuk-details__summary">

--- a/app/views/7-0-0/task.html
+++ b/app/views/7-0-0/task.html
@@ -120,7 +120,7 @@ What would you like to do? – {{ serviceName }} – GOV.UK Prototype Kit
       
           <p>Use this to share information about fraud-related events in your service with GOV.UK One Login and other government services.</p>
 
-            <p>For each event you add, you'll need to include the user ID and select what type of fraud you suspect it to be about.
+            <p>For each event you add, you'll need to include the GOV.UK One Login subject identifier and select what type of fraud you suspect it to be about.
             </p>
          
 


### PR DESCRIPTION
Rename to subject identifier as the standardised name across Fraud pod